### PR TITLE
Bugfix/properly load setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ See [diff-lsp.el](https://www.github.com/C-Hipple/diff-lsp.el) for configuring &
 
 
 diff-lsp.el sets up diff-lsp for both magit status and [code-review](https://www.github.com/C-Hipple/code-review) buffers.
+
+## Limitations
+
+Right now I have a limitation where you can't add more clients for backend servers in a single sesion with the LSP, and you have to restart it.  Normally this is not a problem and is trivial to do.  The reason is because of the types with the backends hashmap being not mutable I'd need to put the whole hashmap behind a mutex which gets me into a ton of rust typing headaches.

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use log::{info, Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
 use tower_lsp::{LspService, Server};
 
 use diff_lsp::server::{create_backends_map, read_initialization_params_from_tempfile, DiffLsp};
-use diff_lsp::utils::fetch_origin_nonblocking;
+use diff_lsp::utils::{fetch_origin_nonblocking, get_most_recent_file};
 
 const LOG_FILE_PATH: &str = "~/.diff-lsp.log";
 
@@ -69,7 +69,9 @@ pub fn initialize_logger() -> Result<(), SetLoggerError> {
 async fn main() {
     let _ = initialize_logger().unwrap();
     let (stdin, stdout) = (tokio::io::stdin(), tokio::io::stdout());
-    let tempfile_path = expanduser("~/.diff-lsp-tempfile").unwrap();
+
+    let tempfile_path = get_most_recent_file("/tmp", "diff_lsp_").unwrap().unwrap();
+    info!("Looking at tempfile: {:?}", tempfile_path);
     let (cwd, langs) = read_initialization_params_from_tempfile(&tempfile_path).unwrap();
     fetch_origin_nonblocking(&cwd);
     let backends = create_backends_map(langs, &cwd);

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,6 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::PathBuf;
 
-use expanduser::expanduser;
 use itertools::Itertools;
 use serde_json::Value;
 use tower_lsp::jsonrpc::{Error as LspError, ErrorCode, Result as LspResult};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,8 @@
 use std::collections::HashSet;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
 use tokio::process::Command;
 
 use log::info;
@@ -22,4 +26,27 @@ pub fn fetch_origin_nonblocking(repo_path: &str) -> tokio::process::Child {
         .arg("origin")
         .spawn()
         .expect("Failed to spawn git fetch command")
+}
+
+pub fn get_most_recent_file(dir_path: &str, prefix: &str) -> io::Result<Option<PathBuf>> {
+    let dir = Path::new(dir_path);
+    let mut most_recent: Option<(PathBuf, SystemTime)> = None;
+
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if let Some(file_name) = path.file_name().and_then(|name| name.to_str()) {
+            if file_name.starts_with(prefix) {
+                let metadata = fs::metadata(&path)?;
+                if metadata.is_file() {
+                    let modified = metadata.modified()?;
+                    if most_recent.is_none() || modified > most_recent.as_ref().unwrap().1 {
+                        most_recent = Some((path, modified));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(most_recent.map(|(path, _)| path))
 }


### PR DESCRIPTION
With the latest changes, we weren't loading a the clients on lsp start, and were relying on refresh file.  However backend clients can only be started at startup (see comment ni readme) and we had switched to a dynamic naming of the tempfile.  Now we just look up that tempfile