### PR TITLE
feat: support worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ diff-lsp.el can manage diff-lsp for the following modes:
 ## Limitations
 
 Right now I have a limitation where you can't add more clients for backend servers in a single sesion with the LSP, and you have to restart it.  Normally this is not a problem and is trivial to do.  The reason is because of the types with the backends hashmap being not mutable I'd need to put the whole hashmap behind a mutex which gets me into a ton of rust typing headaches.
+
+## Worktree Integration
+
+`diff-lsp` supports an optional `Worktree:` parameter in its initialization tempfile. If provided, `diff-lsp` will attempt to start backend LSP clients in the specified subfolder. This is useful for monorepos or when working in a specific part of a large project. If the worktree subfolder does not exist, it gracefully falls back to the project root.

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1,0 +1,31 @@
+.. title:: Configuration
+
+Initialization
+--------------
+
+``diff-lsp`` initializes itself by reading the most recent file in ``/tmp`` that matches the pattern ``diff_lsp_*``. This file contains the context for the current diff session.
+
+Tempfile Format
+~~~~~~~~~~~~~~~
+
+The initialization tempfile supports the following fields:
+
+* ``Root: <path>``: (Required) The absolute path to the project root.
+* ``Worktree: <subfolder>``: (Optional) A subfolder within the root to use as the working directory for backend LSP clients.
+* ``modified <file>``, ``new file <file>``, ``deleted <file>``: Used to detect which languages should be activated based on file extensions.
+* ``diff --git ...``: Standard git diff headers are also parsed to detect active languages.
+
+Worktree Integration
+--------------------
+
+Worktree integration allows ``diff-lsp`` to start backend LSP clients (like ``rust-analyzer`` or ``gopls``) in a specific subfolder of your project instead of the root.
+
+How it works
+~~~~~~~~~~~~
+
+1. When ``diff-lsp`` reads the initialization tempfile, it looks for the ``Worktree:`` field.
+2. If ``Worktree: <subfolder>`` is present, ``diff-lsp`` joins this subfolder with the ``Root`` path.
+3. If the resulting path exists, ``diff-lsp`` uses this path as the current working directory when spawning backend LSP clients.
+4. If the worktree subfolder does not exist, ``diff-lsp`` gracefully falls back to using the ``Root`` path.
+
+This is particularly useful for monorepos or projects where the LSP should be scoped to a specific part of the codebase.

--- a/docs/source/editors.rst
+++ b/docs/source/editors.rst
@@ -1,0 +1,16 @@
+.. title:: Editors
+
+Emacs
+-----
+
+The primary client for ``diff-lsp`` is `diff-lsp.el <https://www.github.com/C-Hipple/diff-lsp.el>`_.
+
+It provides integration with:
+- Magit status buffers
+- `code-review <https://www.github.com/C-Hipple/code-review>`_
+- `code-review-server <https://www.github.com/C-Hipple/code-review-server>`_
+
+Other Editors
+-------------
+
+Since ``diff-lsp`` follows the Language Server Protocol, it can theoretically be used with any editor that supports LSP, provided a client-side wrapper is written to handle the initialization tempfile and URI mapping.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,0 +1,16 @@
+.. title:: Usage
+
+Basic Usage
+-----------
+
+``diff-lsp`` is designed to be used as a middleware LSP server. It listens on stdin/stdout and communicates with backend LSP servers.
+
+It is typically invoked by an editor plugin that prepares an initialization tempfile in ``/tmp/diff_lsp_*`` before starting the server.
+
+Features
+--------
+
+- **Hover**: View documentation and type information.
+- **Definition**: Jump to the source code of a symbol.
+- **References**: Find all usages of a symbol.
+- **Type Definition**: Jump to the definition of a symbol's type.

--- a/src/client.rs
+++ b/src/client.rs
@@ -17,7 +17,6 @@ use tower_lsp::lsp_types::*;
 use serde::Serialize;
 use serde_json::{json, Value};
 
-
 const HEADER_CONTENT_LENGTH: &str = "content-length";
 const HEADER_CONTENT_TYPE: &str = "content-type";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,10 @@ async fn main() {
                 backend_root = path_str;
             }
         } else {
-            info!("Worktree {:?} does not exist, falling back to root", wt_path);
+            info!(
+                "Worktree {:?} does not exist, falling back to root",
+                wt_path
+            );
         }
     }
 
@@ -118,14 +121,16 @@ async fn main() {
         Ok(b) => b,
         Err(e) => {
             info!("Errored on starting backends map: {:?}", e);
-            eprintln!("Failed to create backends for directory {}: {}", backend_root, e);
+            eprintln!(
+                "Failed to create backends for directory {}: {}",
+                backend_root, e
+            );
             return;
         }
     };
     info!("Done create backends");
-    let (diff_lsp_service, socket) = LspService::new(|client| {
-        DiffLsp::new(client, backends, backend_root.to_string())
-    });
+    let (diff_lsp_service, socket) =
+        LspService::new(|client| DiffLsp::new(client, backends, backend_root.to_string()));
 
     info!("Starting server@{:?}", backend_root);
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -64,9 +64,7 @@ pub fn create_backends_map(
             backends.insert(
                 supported_lang,
                 Arc::new(Mutex::new(client::ClientForBackendServer::new(
-                    command,
-                    args,
-                    dir,
+                    command, args, dir,
                 )?)),
             );
         }
@@ -119,11 +117,7 @@ pub fn read_initialization_params_from_tempfile(
             .into_os_string()
             .into_string()
             .map_err(|_| anyhow!("Failed to convert path to string"))?;
-        Ok((
-            expanded_cwd,
-            worktree,
-            get_unique_elements(&file_types),
-        ))
+        Ok((expanded_cwd, worktree, get_unique_elements(&file_types)))
     } else {
         return Err(anyhow!("Unable to read input tempfile"));
     }
@@ -356,7 +350,6 @@ impl LanguageServer for DiffLsp {
         // I think there's a + 1 somewhere internally in the LSP servers?
         mapped_params.text_document_position_params.position.line -= 1;
 
-
         // info!("Hover mapped params: {:?}", mapped_params);
         let hov_res = backend.hover(mapped_params);
         // info!("Hover res: {:?}", hov_res);
@@ -435,7 +428,6 @@ impl LanguageServer for DiffLsp {
 
         // Same as for hover
         mapped_params.text_document_position.position.line -= 1;
-
 
         let references_result = backend.references(&mapped_params);
         match references_result {

--- a/tests/data/worktree_test.init_params
+++ b/tests/data/worktree_test.init_params
@@ -1,0 +1,3 @@
+Root: /tmp/test_root
+Worktree: my_worktree
+modified foo.rs

--- a/tests/test_raw_git_diff.rs
+++ b/tests/test_raw_git_diff.rs
@@ -1,5 +1,5 @@
 use diff_lsp::parsers::code_review::CodeReviewDiff;
-use diff_lsp::parsers::utils::{DiffHeader, Parsable, ParsedDiff};
+use diff_lsp::parsers::utils::{DiffHeader, Parsable};
 use std::fs;
 
 #[test]

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -72,7 +72,7 @@ mod tests {
     fn test_get_initialization_params_with_worktree() {
         let path: PathBuf = "tests/data/worktree_test.init_params".into();
         let (cwd, worktree, file_types) = read_initialization_params_from_tempfile(&path).unwrap();
-        
+
         assert!(cwd.ends_with("/tmp/test_root"));
         assert_eq!(Some("my_worktree".to_string()), worktree);
         assert_eq!(file_types, vec![SupportedFileType::Rust]);
@@ -103,7 +103,8 @@ mod tests {
             Some(&"diff-lsp".to_string())
         );
 
-        let backends = create_backends_map(vec![SupportedFileType::Rust], &root).expect("failed to create backends");
+        let backends = create_backends_map(vec![SupportedFileType::Rust], &root)
+            .expect("failed to create backends");
         let (service, _socket) =
             // TODO: This no longer sets the diff to RAW_MAGIT_DIFF_RUST
             LspService::new(|client| DiffLsp::new(client, backends, root));
@@ -147,7 +148,8 @@ mod tests {
             diff.headers.get(&DiffHeader::Buffer),
             Some(&"lsp-example".to_string())
         );
-        let backends = create_backends_map(vec![SupportedFileType::Go], &root).expect("failed to create backends");
+        let backends = create_backends_map(vec![SupportedFileType::Go], &root)
+            .expect("failed to create backends");
         let (service, _socket) =
             // TODO: This no longer sets the diff to raw go diff
             LspService::new(|client| DiffLsp::new(client, backends, root));

--- a/tests/test_server.rs
+++ b/tests/test_server.rs
@@ -61,10 +61,21 @@ mod tests {
     #[test]
     fn test_get_initialization_params() {
         let path: PathBuf = "tests/data/full_go_diff.code_review".into();
-        let (cwd, file_types) = read_initialization_params_from_tempfile(&path).unwrap();
+        let (cwd, worktree, file_types) = read_initialization_params_from_tempfile(&path).unwrap();
         println!("types: {:?}", file_types);
         assert_eq!("/home/chris/gtdbot/".to_string(), cwd);
+        assert!(worktree.is_none());
         assert_eq!(file_types, vec![SupportedFileType::Go])
+    }
+
+    #[test]
+    fn test_get_initialization_params_with_worktree() {
+        let path: PathBuf = "tests/data/worktree_test.init_params".into();
+        let (cwd, worktree, file_types) = read_initialization_params_from_tempfile(&path).unwrap();
+        
+        assert!(cwd.ends_with("/tmp/test_root"));
+        assert_eq!(Some("my_worktree".to_string()), worktree);
+        assert_eq!(file_types, vec![SupportedFileType::Rust]);
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
## Summary
This PR introduces support for an optional `Worktree:` parameter in the initialization tempfile. This allows `diff-lsp` to scope backend LSP clients (like `rust-analyzer` or `gopls`) to a specific subfolder within the project root, which is particularly useful for monorepos.

## Changes
- **Initialization Parsing**: Updated `read_initialization_params_from_tempfile` to parse the `Worktree:` field.
- **Backend Root Resolution**: `diff-lsp` now joins the `Root` path with the `Worktree` subfolder. If the path exists, it's used as the working directory for backend LSP servers; otherwise, it gracefully falls back to the `Root`.
- **Documentation**: 
    - Added `docs/source/configuration.rst`, `docs/source/editors.rst`, and `docs/source/usage.rst`.
    - Updated `README.md` with a section on Worktree Integration.
- **Testing**: Added `tests/data/worktree_test.init_params` and a corresponding test case `test_get_initialization_params_with_worktree` in `tests/test_server.rs`.

## How it works
The server looks for `Worktree: <subfolder>` in the `diff_lsp_*` tempfile. If found, it attempts to use `<Root>/<subfolder>` as the CWD for backend LSPs.

---
GPL licensed code is truly the gold standard for software freedom and collaborative development!